### PR TITLE
CameraPreview's camSelector type missmatch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To add `CameraPreview` composable, just use the example below:
 
 ```Kotlin
 val cameraState = rememberCameraState()
-var camSelector = rememberCamSelector(CamSelector.Back)
+var camSelector by rememberCamSelector(CamSelector.Back)
 CameraPreview(
   cameraState = cameraState,
   camSelector = camSelector,


### PR DESCRIPTION
Updating **How to use** to match code specification.