### PR TITLE
Add ability to declare output ImageCaptureTargetSize

### DIFF
--- a/camposer/src/androidTest/java/com/ujizin/camposer/ImageCaptureTargetSizeTest.kt
+++ b/camposer/src/androidTest/java/com/ujizin/camposer/ImageCaptureTargetSizeTest.kt
@@ -1,0 +1,51 @@
+package com.ujizin.camposer
+
+import android.util.Size
+import androidx.camera.camera2.internal.compat.workaround.TargetAspectRatio.RATIO_16_9
+import androidx.camera.view.CameraController.OutputSize
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+internal class ImageCaptureTargetSizeTest : CameraTest() {
+
+    private lateinit var imageCaptureTargetSize: MutableState<OutputSize>
+
+    @Test
+    fun test_imageCaptureTargetSize() = with(composeTestRule) {
+        initImageCaptureTargetSizeCamera(OutputSize(RATIO_16_9))
+
+        runOnIdle { assertEqualSize(cameraState.imageCaptureTargetSize, OutputSize(RATIO_16_9)) }
+
+        imageCaptureTargetSize.value = OutputSize(Size(1600, 1200))
+
+        runOnIdle { assertEqualSize(cameraState.imageCaptureTargetSize, OutputSize(Size(1600, 1200))) }
+    }
+
+    private fun ComposeContentTestRule.initImageCaptureTargetSizeCamera(
+        initialValue: OutputSize
+    ) = initCameraState { state ->
+        imageCaptureTargetSize = remember { mutableStateOf(initialValue) }
+        CameraPreview(
+            cameraState = state,
+            imageCaptureTargetSize = imageCaptureTargetSize.value,
+        )
+    }
+
+    private fun assertEqualSize(
+        size1: OutputSize?,
+        size2: OutputSize?
+    ) {
+        assertEquals(size1?.resolution?.height, size2?.resolution?.height)
+        assertEquals(size1?.resolution?.width, size2?.resolution?.width)
+        assertEquals(size1?.aspectRatio, size2?.aspectRatio)
+    }
+}

--- a/camposer/src/androidTest/java/com/ujizin/camposer/ImageCaptureTargetSizeTest.kt
+++ b/camposer/src/androidTest/java/com/ujizin/camposer/ImageCaptureTargetSizeTest.kt
@@ -2,13 +2,13 @@ package com.ujizin.camposer
 
 import android.util.Size
 import androidx.camera.camera2.internal.compat.workaround.TargetAspectRatio.RATIO_16_9
-import androidx.camera.view.CameraController.OutputSize
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.ujizin.camposer.state.ImageTargetSize
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,21 +17,31 @@ import org.junit.runner.RunWith
 @LargeTest
 internal class ImageCaptureTargetSizeTest : CameraTest() {
 
-    private lateinit var imageCaptureTargetSize: MutableState<OutputSize>
+    private lateinit var imageCaptureTargetSize: MutableState<ImageTargetSize>
 
     @Test
     fun test_imageCaptureTargetSize() = with(composeTestRule) {
-        initImageCaptureTargetSizeCamera(OutputSize(RATIO_16_9))
+        initImageCaptureTargetSizeCamera(ImageTargetSize(RATIO_16_9))
 
-        runOnIdle { assertEqualSize(cameraState.imageCaptureTargetSize, OutputSize(RATIO_16_9)) }
+        runOnIdle {
+            assertEqualSize(
+                cameraState.imageCaptureTargetSize,
+                ImageTargetSize(RATIO_16_9)
+            )
+        }
 
-        imageCaptureTargetSize.value = OutputSize(Size(1600, 1200))
+        imageCaptureTargetSize.value = ImageTargetSize(Size(1600, 1200))
 
-        runOnIdle { assertEqualSize(cameraState.imageCaptureTargetSize, OutputSize(Size(1600, 1200))) }
+        runOnIdle {
+            assertEqualSize(
+                cameraState.imageCaptureTargetSize,
+                ImageTargetSize(Size(1600, 1200))
+            )
+        }
     }
 
     private fun ComposeContentTestRule.initImageCaptureTargetSizeCamera(
-        initialValue: OutputSize
+        initialValue: ImageTargetSize
     ) = initCameraState { state ->
         imageCaptureTargetSize = remember { mutableStateOf(initialValue) }
         CameraPreview(
@@ -41,11 +51,14 @@ internal class ImageCaptureTargetSizeTest : CameraTest() {
     }
 
     private fun assertEqualSize(
-        size1: OutputSize?,
-        size2: OutputSize?
+        size1: ImageTargetSize?,
+        size2: ImageTargetSize?
     ) {
-        assertEquals(size1?.resolution?.height, size2?.resolution?.height)
-        assertEquals(size1?.resolution?.width, size2?.resolution?.width)
-        assertEquals(size1?.aspectRatio, size2?.aspectRatio)
+        val size1OutputSize = size1?.toOutputSize()
+        val size2OutputSize = size2?.toOutputSize()
+
+        assertEquals(size1OutputSize?.resolution?.height, size2OutputSize?.resolution?.height)
+        assertEquals(size1OutputSize?.resolution?.width, size2OutputSize?.resolution?.width)
+        assertEquals(size1OutputSize?.aspectRatio, size2OutputSize?.aspectRatio)
     }
 }

--- a/camposer/src/androidTest/java/com/ujizin/camposer/ImageCaptureTargetSizeTest.kt
+++ b/camposer/src/androidTest/java/com/ujizin/camposer/ImageCaptureTargetSizeTest.kt
@@ -24,7 +24,7 @@ internal class ImageCaptureTargetSizeTest : CameraTest() {
         initImageCaptureTargetSizeCamera(ImageTargetSize(RATIO_16_9))
 
         runOnIdle {
-            assertEqualSize(
+            assertEquals(
                 cameraState.imageCaptureTargetSize,
                 ImageTargetSize(RATIO_16_9)
             )
@@ -33,7 +33,7 @@ internal class ImageCaptureTargetSizeTest : CameraTest() {
         imageCaptureTargetSize.value = ImageTargetSize(Size(1600, 1200))
 
         runOnIdle {
-            assertEqualSize(
+            assertEquals(
                 cameraState.imageCaptureTargetSize,
                 ImageTargetSize(Size(1600, 1200))
             )
@@ -48,17 +48,5 @@ internal class ImageCaptureTargetSizeTest : CameraTest() {
             cameraState = state,
             imageCaptureTargetSize = imageCaptureTargetSize.value,
         )
-    }
-
-    private fun assertEqualSize(
-        size1: ImageTargetSize?,
-        size2: ImageTargetSize?
-    ) {
-        val size1OutputSize = size1?.toOutputSize()
-        val size2OutputSize = size2?.toOutputSize()
-
-        assertEquals(size1OutputSize?.resolution?.height, size2OutputSize?.resolution?.height)
-        assertEquals(size1OutputSize?.resolution?.width, size2OutputSize?.resolution?.width)
-        assertEquals(size1OutputSize?.aspectRatio, size2OutputSize?.aspectRatio)
     }
 }

--- a/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
@@ -3,6 +3,7 @@ package com.ujizin.camposer
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.view.ViewGroup
+import androidx.camera.view.CameraController
 import androidx.camera.view.PreviewView
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -62,6 +63,7 @@ public fun CameraPreview(
     cameraState: CameraState = rememberCameraState(),
     camSelector: CamSelector = cameraState.camSelector,
     captureMode: CaptureMode = cameraState.captureMode,
+    imageCaptureTargetSize: CameraController.OutputSize? = cameraState.imageCaptureTargetSize,
     flashMode: FlashMode = cameraState.flashMode,
     scaleType: ScaleType = cameraState.scaleType,
     enableTorch: Boolean = cameraState.enableTorch,
@@ -87,6 +89,7 @@ public fun CameraPreview(
         cameraState = cameraState,
         camSelector = camSelector,
         captureMode = captureMode,
+        imageCaptureTargetSize = imageCaptureTargetSize,
         flashMode = flashMode,
         scaleType = scaleType,
         enableTorch = enableTorch,
@@ -113,6 +116,7 @@ internal fun CameraPreviewImpl(
     cameraState: CameraState,
     camSelector: CamSelector,
     captureMode: CaptureMode,
+    imageCaptureTargetSize: CameraController.OutputSize?,
     flashMode: FlashMode,
     scaleType: ScaleType,
     enableTorch: Boolean,
@@ -143,6 +147,8 @@ internal fun CameraPreviewImpl(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
             )
             controller = cameraState.controller.apply {
+                cameraState.controller.imageCaptureTargetSize = imageCaptureTargetSize
+
                 bindToLifecycle(lifecycleOwner)
             }
 
@@ -175,6 +181,7 @@ internal fun CameraPreviewImpl(
                 cameraState.update(
                     camSelector = camSelector,
                     captureMode = captureMode,
+                    imageCaptureTargetSize = imageCaptureTargetSize,
                     scaleType = scaleType,
                     isImageAnalysisEnabled = isImageAnalysisEnabled,
                     imageAnalyzer = imageAnalyzer,

--- a/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
@@ -3,7 +3,6 @@ package com.ujizin.camposer
 import android.annotation.SuppressLint
 import android.graphics.Bitmap
 import android.view.ViewGroup
-import androidx.camera.view.CameraController
 import androidx.camera.view.PreviewView
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -26,6 +25,7 @@ import com.ujizin.camposer.state.CameraState
 import com.ujizin.camposer.state.CaptureMode
 import com.ujizin.camposer.state.FlashMode
 import com.ujizin.camposer.state.ImageAnalyzer
+import com.ujizin.camposer.state.ImageTargetSize
 import com.ujizin.camposer.state.ImplementationMode
 import com.ujizin.camposer.state.ScaleType
 import com.ujizin.camposer.state.rememberCameraState
@@ -64,7 +64,7 @@ public fun CameraPreview(
     cameraState: CameraState = rememberCameraState(),
     camSelector: CamSelector = cameraState.camSelector,
     captureMode: CaptureMode = cameraState.captureMode,
-    imageCaptureTargetSize: CameraController.OutputSize? = cameraState.imageCaptureTargetSize,
+    imageCaptureTargetSize: ImageTargetSize? = cameraState.imageCaptureTargetSize,
     flashMode: FlashMode = cameraState.flashMode,
     scaleType: ScaleType = cameraState.scaleType,
     enableTorch: Boolean = cameraState.enableTorch,
@@ -117,7 +117,7 @@ internal fun CameraPreviewImpl(
     cameraState: CameraState,
     camSelector: CamSelector,
     captureMode: CaptureMode,
-    imageCaptureTargetSize: CameraController.OutputSize?,
+    imageCaptureTargetSize: ImageTargetSize?,
     flashMode: FlashMode,
     scaleType: ScaleType,
     enableTorch: Boolean,
@@ -148,7 +148,7 @@ internal fun CameraPreviewImpl(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT
             )
             controller = cameraState.controller.apply {
-                cameraState.controller.imageCaptureTargetSize = imageCaptureTargetSize
+                cameraState.controller.imageCaptureTargetSize = imageCaptureTargetSize?.toOutputSize()
 
                 bindToLifecycle(lifecycleOwner)
             }

--- a/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
@@ -38,6 +38,7 @@ import androidx.camera.core.CameraSelector as CameraXSelector
  * @param cameraState camera state hold some states and camera's controller, it can be useful to given action like [CameraState.takePicture]
  * @param camSelector camera selector to be added, default is back
  * @param captureMode camera capture mode, default is image
+ * @param imageCaptureTargetSize suggested target size for image camera capture, default is camera's preferred size
  * @param flashMode flash mode to be added, default is off
  * @param scaleType scale type to be added, default is fill center
  * @param enableTorch enable torch from camera, default is false.

--- a/camposer/src/main/java/com/ujizin/camposer/state/CameraAsState.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/CameraAsState.kt
@@ -64,7 +64,7 @@ public fun CameraState.rememberTorch(
 @Composable
 public fun CameraState.rememberImageAnalyzer(
     imageAnalysisBackpressureStrategy: ImageAnalysisBackpressureStrategy = ImageAnalysisBackpressureStrategy.KeepOnlyLatest,
-    imageAnalysisTargetSize: ImageAnalysisTargetSize? = ImageAnalysisTargetSize(this.imageAnalysisTargetSize),
+    imageAnalysisTargetSize: ImageTargetSize? = ImageTargetSize(this.imageAnalysisTargetSize),
     imageAnalysisImageQueueDepth: Int = this.imageAnalysisImageQueueDepth,
     analyze: (ImageProxy) -> Unit,
 ): ImageAnalyzer = remember(this) {

--- a/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
@@ -146,6 +146,19 @@ public class CameraState internal constructor(context: Context) {
         }
 
     /**
+     * Set image capture target size on camera
+     * */
+    internal var imageCaptureTargetSize: OutputSize?
+        get() = controller.imageCaptureTargetSize
+        set(value) {
+            if (imageCaptureTargetSize?.aspectRatio != value?.aspectRatio
+                && imageCaptureTargetSize?.resolution != value?.resolution
+            ) {
+                controller.imageCaptureTargetSize = value
+            }
+        }
+
+    /**
      * Get Image Analyzer from camera.
      * */
     internal var imageAnalyzer: ImageAnalysis.Analyzer? = null
@@ -479,6 +492,7 @@ public class CameraState internal constructor(context: Context) {
         camSelector: CamSelector,
         captureMode: CaptureMode,
         scaleType: ScaleType,
+        imageCaptureTargetSize: OutputSize?,
         isImageAnalysisEnabled: Boolean,
         imageAnalyzer: ImageAnalyzer?,
         implementationMode: ImplementationMode,
@@ -491,6 +505,7 @@ public class CameraState internal constructor(context: Context) {
         this.camSelector = camSelector
         this.captureMode = captureMode
         this.scaleType = scaleType
+        this.imageCaptureTargetSize = imageCaptureTargetSize
         this.isImageAnalysisEnabled = isImageAnalysisEnabled
         this.imageAnalyzer = imageAnalyzer?.analyzer
         this.implementationMode = implementationMode

--- a/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
@@ -152,12 +152,7 @@ public class CameraState internal constructor(context: Context) {
     internal var imageCaptureTargetSize: ImageTargetSize?
         get() = controller.imageCaptureTargetSize.toImageTargetSize()
         set(value) {
-            val valueOutputSize = value?.toOutputSize()
-            val existingOutputSize = imageCaptureTargetSize?.toOutputSize()
-
-            if (existingOutputSize?.aspectRatio != valueOutputSize?.aspectRatio
-                && existingOutputSize?.resolution != valueOutputSize?.resolution
-            ) {
+            if (value != imageCaptureTargetSize) {
                 controller.imageCaptureTargetSize = value?.toOutputSize()
             }
         }

--- a/camposer/src/main/java/com/ujizin/camposer/state/ImageAnalyzer.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/ImageAnalyzer.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Immutable
 public class ImageAnalyzer(
     private val cameraState: CameraState,
     imageAnalysisBackpressureStrategy: ImageAnalysisBackpressureStrategy,
-    imageAnalysisTargetSize: ImageAnalysisTargetSize?,
+    imageAnalysisTargetSize: ImageTargetSize?,
     imageAnalysisImageQueueDepth: Int,
     private var analyzerCallback: (ImageProxy) -> Unit,
 ) {
@@ -38,7 +38,7 @@ public class ImageAnalyzer(
 
     private fun updateCameraState(
         imageAnalysisBackpressureStrategy: ImageAnalysisBackpressureStrategy,
-        imageAnalysisTargetSize: ImageAnalysisTargetSize?,
+        imageAnalysisTargetSize: ImageTargetSize?,
         imageAnalysisImageQueueDepth: Int,
     ) = with(cameraState) {
         this.imageAnalysisBackpressureStrategy = imageAnalysisBackpressureStrategy.strategy
@@ -60,7 +60,7 @@ public class ImageAnalyzer(
         imageAnalysisBackpressureStrategy: ImageAnalysisBackpressureStrategy = ImageAnalysisBackpressureStrategy.find(
             cameraState.imageAnalysisBackpressureStrategy
         ),
-        imageAnalysisTargetSize: ImageAnalysisTargetSize? = ImageAnalysisTargetSize(cameraState.imageAnalysisTargetSize),
+        imageAnalysisTargetSize: ImageTargetSize? = ImageTargetSize(cameraState.imageAnalysisTargetSize),
         imageAnalysisImageQueueDepth: Int = cameraState.imageAnalysisImageQueueDepth,
         analyzerCallback: (ImageProxy) -> Unit = this.analyzerCallback,
     ) {

--- a/camposer/src/main/java/com/ujizin/camposer/state/ImageTargetSize.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/ImageTargetSize.kt
@@ -8,7 +8,7 @@ import androidx.camera.view.CameraController.OutputSize
  * Image Analysis target size is used to target the size of image analysis, accepting [AspectRatio]
  * or [Size].
  * */
-public class ImageAnalysisTargetSize {
+public class ImageTargetSize {
 
     private var aspectRatio: Int? = null
     private var size: Size? = null

--- a/camposer/src/main/java/com/ujizin/camposer/state/ImageTargetSize.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/ImageTargetSize.kt
@@ -8,32 +8,38 @@ import androidx.camera.view.CameraController.OutputSize
  * Image Analysis target size is used to target the size of image analysis, accepting [AspectRatio]
  * or [Size].
  * */
-public class ImageTargetSize {
-
-    private var aspectRatio: Int? = null
-    private var size: Size? = null
+public data class ImageTargetSize(
+    private var aspectRatio: Int? = null,
+    private var size: Size? = null,
     private var outputSize: OutputSize? = null
+) {
 
     /**
      * Image analysis target size using [AspectRatio].
      * */
-    public constructor(@AspectRatio.Ratio aspectRatio: Int?) {
-        this.aspectRatio = aspectRatio
-    }
+    public constructor(@AspectRatio.Ratio aspectRatio: Int?) : this(
+        aspectRatio = aspectRatio,
+        size = null,
+        outputSize = null
+    )
 
     /**
      * Image analysis target size using [Size].
      * */
-    public constructor(size: Size?) {
-        this.size = size
-    }
+    public constructor(size: Size?) : this(
+        aspectRatio = null,
+        size = size,
+        outputSize = null
+    )
 
     /**
      * Internal constructor to use default [OutputSize] from cameraX.
      * */
-    internal constructor(outputSize: OutputSize?) {
-        this.outputSize = outputSize
-    }
+    internal constructor(outputSize: OutputSize?) : this(
+        aspectRatio = null,
+        size = null,
+        outputSize = outputSize
+    )
 
     internal fun toOutputSize(): OutputSize? {
         return outputSize ?: aspectRatio?.let { OutputSize(it) } ?: size?.let { OutputSize(it) }


### PR DESCRIPTION
I need control over the size of the image the camera creates, so I added a configuration that allows this customization.