### PR TITLE
Restrict video capture to api level 22 above

### DIFF
--- a/camposer/src/androidTest/java/com/ujizin/camposer/CaptureModeTest.kt
+++ b/camposer/src/androidTest/java/com/ujizin/camposer/CaptureModeTest.kt
@@ -85,6 +85,8 @@ internal class CaptureModeTest : CameraTest() {
             isAnalyzeCalled = true
         }
 
+        if (!cameraState.isImageAnalysisSupported) return
+
         runOnIdle {
             val videoFile = File(context.filesDir, VIDEO_TEST_FILENAME).apply { createNewFile() }
 
@@ -118,8 +120,10 @@ internal class CaptureModeTest : CameraTest() {
         CameraPreview(
             cameraState = state,
             captureMode = captureMode,
-            imageAnalyzer = analyzer?.let { state.rememberImageAnalyzer(analyze = it) },
-            isImageAnalysisEnabled = analyzer != null
+            imageAnalyzer = analyzer?.takeIf {
+                cameraState.isImageAnalysisSupported
+            }?.let { state.rememberImageAnalyzer(analyze = it) },
+            isImageAnalysisEnabled = cameraState.isImageAnalysisSupported && analyzer != null
         )
     }
 

--- a/camposer/src/main/java/com/ujizin/camposer/extensions/CameraStateExtensions.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/extensions/CameraStateExtensions.kt
@@ -2,7 +2,9 @@ package com.ujizin.camposer.extensions
 
 import android.content.ContentValues
 import android.net.Uri
+import android.os.Build
 import android.provider.MediaStore
+import androidx.annotation.RequiresApi
 import androidx.camera.core.ImageCapture
 import androidx.camera.view.video.OutputFileOptions
 import com.ujizin.camposer.state.CameraState
@@ -43,6 +45,7 @@ public suspend fun CameraState.takePicture(
 /**
  * Transform toggle recording file to suspend function
  * */
+@RequiresApi(Build.VERSION_CODES.M)
 public suspend fun CameraState.toggleRecording(file: File): Uri? = suspendCancellableCoroutine { cont ->
     with(cont) { toggleRecording(file, ::toggleRecordContinuation) }
 }
@@ -50,6 +53,7 @@ public suspend fun CameraState.toggleRecording(file: File): Uri? = suspendCancel
 /**
  * Transform toggle recording content values options to suspend function
  * */
+@RequiresApi(Build.VERSION_CODES.M)
 public suspend fun CameraState.toggleRecording(
     contentValues: ContentValues,
     saveCollection: Uri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI
@@ -60,6 +64,7 @@ public suspend fun CameraState.toggleRecording(
 /**
  * Transform toggle recording output files options to suspend function
  * */
+@RequiresApi(Build.VERSION_CODES.M)
 public suspend fun CameraState.toggleRecording(
     outputFileOptions: OutputFileOptions
 ): Uri? = suspendCancellableCoroutine { cont ->

--- a/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
@@ -6,9 +6,12 @@ import android.content.ContentValues
 import android.content.Context
 import android.hardware.camera2.CameraManager
 import android.net.Uri
+import android.os.Build
 import android.provider.MediaStore
 import android.util.Log
+import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.OptIn
+import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import androidx.camera.core.FocusMeteringAction
 import androidx.camera.core.ImageAnalysis
@@ -323,6 +326,13 @@ public class CameraState(context: Context) {
         }
 
     /**
+     * Return if video is supported.
+     * */
+
+    @ChecksSdkIntAtLeast(Build.VERSION_CODES.M)
+    public var isVideoSupported: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+
+    /**
      * Return true if it's recording.
      * */
     @ExperimentalVideo
@@ -417,6 +427,7 @@ public class CameraState(context: Context) {
      * @param onResult Callback called when [VideoCaptureResult] is ready
      * */
     @OptIn(markerClass = [ExperimentalVideo::class])
+    @RequiresApi(Build.VERSION_CODES.M)
     public fun startRecording(file: File, onResult: (VideoCaptureResult) -> Unit) {
         startRecording(OutputFileOptions.builder(file).build(), onResult)
     }
@@ -429,6 +440,7 @@ public class CameraState(context: Context) {
      *  @param onResult Callback called when [VideoCaptureResult] is ready
      *  */
     @OptIn(markerClass = [ExperimentalVideo::class])
+    @RequiresApi(Build.VERSION_CODES.M)
     public fun startRecording(
         saveCollection: Uri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
         contentValues: ContentValues,
@@ -447,6 +459,7 @@ public class CameraState(context: Context) {
      * @param onResult Callback called when [VideoCaptureResult] is ready
      * */
     @ExperimentalVideo
+    @RequiresApi(Build.VERSION_CODES.M)
     public fun startRecording(
         outputFileOptions: OutputFileOptions,
         onResult: (VideoCaptureResult) -> Unit,
@@ -484,6 +497,7 @@ public class CameraState(context: Context) {
      * Stop recording camera.
      * */
     @OptIn(markerClass = [ExperimentalVideo::class])
+    @RequiresApi(Build.VERSION_CODES.M)
     public fun stopRecording() {
         controller.stopRecording()
     }
@@ -491,6 +505,7 @@ public class CameraState(context: Context) {
     /**
      * Toggle recording camera.
      * */
+    @RequiresApi(Build.VERSION_CODES.M)
     public fun toggleRecording(
         file: File,
         onResult: (VideoCaptureResult) -> Unit
@@ -504,6 +519,7 @@ public class CameraState(context: Context) {
     /**
      * Toggle recording camera.
      * */
+    @RequiresApi(Build.VERSION_CODES.M)
     public fun toggleRecording(
         contentValues: ContentValues,
         saveCollection: Uri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
@@ -518,6 +534,7 @@ public class CameraState(context: Context) {
     /**
      * Toggle recording camera.
      * */
+    @RequiresApi(Build.VERSION_CODES.M)
     @OptIn(markerClass = [ExperimentalVideo::class])
     public fun toggleRecording(
         outputFileOptions: OutputFileOptions,

--- a/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/CameraState.kt
@@ -218,11 +218,6 @@ public class CameraState(context: Context) {
             }
         }
 
-    /**
-     * CameraX's use cases captures.
-     * */
-    private val useCases: MutableSet<Int> = mutableSetOf(IMAGE_ANALYSIS)
-
     private val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as? CameraManager
 
     /**
@@ -230,6 +225,13 @@ public class CameraState(context: Context) {
      * */
     public var isImageAnalysisSupported: Boolean by mutableStateOf(isImageAnalysisSupported(camSelector))
         private set
+
+    /**
+     * CameraX's use cases captures.
+     * */
+    private val captureUseCases: MutableSet<Int> = mutableSetOf<Int>().apply {
+        if (isImageAnalysisSupported) add(IMAGE_ANALYSIS)
+    }
 
     /**
      * Enable/Disable Image analysis from the camera.
@@ -242,7 +244,7 @@ public class CameraState(context: Context) {
             }
 
             if (value != field) {
-                if (value) useCases += IMAGE_ANALYSIS else useCases -= IMAGE_ANALYSIS
+                if (value) captureUseCases += IMAGE_ANALYSIS else captureUseCases -= IMAGE_ANALYSIS
                 updateUseCases()
                 field = value
             }
@@ -250,7 +252,7 @@ public class CameraState(context: Context) {
 
     private fun updateUseCases() {
         try {
-            controller.setEnabledUseCases(useCases.sumOr(captureMode.value))
+            controller.setEnabledUseCases(captureUseCases.sumOr(captureMode.value))
         } catch (exception: IllegalStateException) {
             Log.e(TAG, "Use case Image Analysis not supported")
             controller.setEnabledUseCases(captureMode.value)

--- a/camposer/src/main/java/com/ujizin/camposer/state/CaptureMode.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/state/CaptureMode.kt
@@ -1,6 +1,8 @@
 package com.ujizin.camposer.state
 
+import android.os.Build
 import androidx.annotation.OptIn
+import androidx.annotation.RequiresApi
 import androidx.camera.view.CameraController.IMAGE_CAPTURE
 import androidx.camera.view.CameraController.VIDEO_CAPTURE
 import androidx.camera.view.video.ExperimentalVideo
@@ -15,5 +17,6 @@ import androidx.camera.view.video.ExperimentalVideo
 @OptIn(markerClass = [ExperimentalVideo::class])
 public enum class CaptureMode(internal val value: Int) {
     Image(IMAGE_CAPTURE),
+    @RequiresApi(Build.VERSION_CODES.M)
     Video(VIDEO_CAPTURE),
 }

--- a/sample/src/main/java/com/ujizin/sample/feature/camera/CameraScreen.kt
+++ b/sample/src/main/java/com/ujizin/sample/feature/camera/CameraScreen.kt
@@ -130,6 +130,7 @@ fun CameraSection(
             cameraOption = cameraOption,
             hasFlashUnit = hasFlashUnit,
             qrCodeText = qrCodeText,
+            isVideoSupported = cameraState.isVideoSupported,
             onFlashModeChanged = { flash ->
                 enableTorch = flash == Flash.Always
                 flashMode = flash.toFlashMode()
@@ -161,6 +162,7 @@ fun CameraInnerContent(
     hasFlashUnit: Boolean,
     qrCodeText: String?,
     lastPicture: File?,
+    isVideoSupported: Boolean,
     onGalleryClick: () -> Unit,
     onFlashModeChanged: (Flash) -> Unit,
     onZoomFinish: () -> Unit,
@@ -199,6 +201,7 @@ fun CameraInnerContent(
             qrCodeText = qrCodeText,
             onTakePicture = onTakePicture,
             isRecording = isRecording,
+            isVideoSupported = isVideoSupported,
             onRecording = onRecording,
             onSwitchCamera = onSwitchCamera,
             onCameraOptionChanged = onCameraOptionChanged,

--- a/sample/src/main/java/com/ujizin/sample/feature/camera/CameraViewModel.kt
+++ b/sample/src/main/java/com/ujizin/sample/feature/camera/CameraViewModel.kt
@@ -8,6 +8,9 @@ import android.util.Log
 import androidx.camera.core.ImageProxy
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.DecodeHintType
+import com.google.zxing.MultiFormatReader
 import com.ujizin.camposer.state.CameraState
 import com.ujizin.camposer.state.ImageCaptureResult
 import com.ujizin.camposer.state.VideoCaptureResult
@@ -15,9 +18,6 @@ import com.ujizin.sample.data.local.datasource.FileDataSource
 import com.ujizin.sample.data.local.datasource.UserDataSource
 import com.ujizin.sample.domain.User
 import com.ujizin.sample.extensions.getQRCodeResult
-import com.google.zxing.BarcodeFormat
-import com.google.zxing.DecodeHintType
-import com.google.zxing.MultiFormatReader
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
@@ -80,10 +80,12 @@ class CameraViewModel(
                     onResult = ::onVideoResult
                 )
 
-                else -> toggleRecording(
-                    fileDataSource.getFile("mp4"),
-                    onResult = ::onVideoResult
-                )
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> {
+                    toggleRecording(
+                        fileDataSource.getFile("mp4"),
+                        onResult = ::onVideoResult
+                    )
+                }
             }
         }
     }

--- a/sample/src/main/java/com/ujizin/sample/feature/camera/components/ActionsBox.kt
+++ b/sample/src/main/java/com/ujizin/sample/feature/camera/components/ActionsBox.kt
@@ -16,6 +16,7 @@ fun ActionBox(
     isRecording: Boolean,
     qrCodeText: String?,
     lastPicture: File?,
+    isVideoSupported: Boolean,
     onGalleryClick: () -> Unit,
     onTakePicture: () -> Unit,
     onSwitchCamera: () -> Unit,
@@ -32,6 +33,7 @@ fun ActionBox(
             qrCodeText = qrCodeText)
         OptionSection(
             modifier = Modifier.fillMaxWidth(),
+            isVideoSupported = isVideoSupported,
             currentCameraOption = cameraOption,
             onCameraOptionChanged = onCameraOptionChanged
         )

--- a/sample/src/main/java/com/ujizin/sample/feature/camera/components/OptionSection.kt
+++ b/sample/src/main/java/com/ujizin/sample/feature/camera/components/OptionSection.kt
@@ -17,10 +17,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ujizin.sample.feature.camera.model.CameraOption
+
 @Composable
 fun OptionSection(
     modifier: Modifier = Modifier,
     currentCameraOption: CameraOption,
+    isVideoSupported: Boolean,
     onCameraOptionChanged: (CameraOption) -> Unit,
 ) {
     Row(
@@ -28,6 +30,8 @@ fun OptionSection(
         horizontalArrangement = Arrangement.Center,
     ) {
         CameraOption.values().forEach { option ->
+            if (!isVideoSupported && option == CameraOption.Video) return@forEach
+
             Text(
                 modifier = Modifier
                     .clickable(

--- a/sample/src/main/java/com/ujizin/sample/feature/camera/model/CameraOption.kt
+++ b/sample/src/main/java/com/ujizin/sample/feature/camera/model/CameraOption.kt
@@ -1,5 +1,6 @@
 package com.ujizin.sample.feature.camera.model
 
+import android.os.Build
 import androidx.annotation.StringRes
 import com.ujizin.camposer.state.CaptureMode
 import com.ujizin.sample.R
@@ -11,6 +12,10 @@ enum class CameraOption(@StringRes val titleRes: Int) {
 
     fun toCaptureMode(): CaptureMode = when(this) {
         QRCode, Photo -> CaptureMode.Image
-        Video -> CaptureMode.Video
+        Video -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            CaptureMode.Video
+        } else {
+            throw IllegalStateException("Camera state not support video capture mode")
+        }
     }
 }


### PR DESCRIPTION
# What's changed

- Restrict video capture mode to api level 22 above
- Fix capture mode test for image analysis not supported
- remove default image analysis use case when is not supported