### PR TITLE
change the scale type only if necessary

### DIFF
--- a/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
+++ b/camposer/src/main/java/com/ujizin/camposer/CameraPreview.kt
@@ -178,7 +178,7 @@ internal fun CameraPreviewImpl(
         update = { previewView ->
             if (cameraIsInitialized) {
                 with(previewView) {
-                    if( this.scaleType != scaleType.type) {
+                    if (this.scaleType != scaleType.type) {
                         this.scaleType = scaleType.type
                     }
                     this.implementationMode = implementationMode.value


### PR DESCRIPTION
Always reassigning a value, even if it's the same, modifies the PreviewView.StreamState, which then recomposes, creating an init loop that makes my phone freeze and slows down photo taking.
This lag appeared with CameraX 1.4.2. I'm not sure why I didn't look into it further, but adding this check allows for proper use of Camposer.


I talked about it a bit here because modifying the Modifier makes it really slow for me anyway.
#34 