### PR TITLE
fix(camera-session): crash when camera is initialized in Fragment (Context wrapper)

### DIFF
--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -37,7 +37,7 @@ jobs:
             target: default
           - api-level: 26
             arch: 'x86_64'
-            target: default
+            target: google_apis
           - api-level: 31
             arch: 'x86_64'
             target: google_apis

--- a/.github/workflows/android_test.yml
+++ b/.github/workflows/android_test.yml
@@ -72,7 +72,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
+          key: avd-${{ matrix.api-level }}-${{ matrix.target }}
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
@@ -23,7 +23,6 @@ import androidx.core.util.Consumer
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import com.ujizin.camposer.extensions.compatMainExecutor
-import com.ujizin.camposer.extensions.findLifecycleOwner
 import java.util.concurrent.Executor
 
 /**
@@ -36,9 +35,8 @@ import java.util.concurrent.Executor
  */
 internal class CameraXControllerWrapper(
   context: Context,
+  override val lifecycleOwner: LifecycleOwner,
 ) : CameraXController {
-  override val lifecycleOwner = context.findLifecycleOwner()
-
   override val contentResolver: ContentResolver = context.contentResolver
 
   override val mainExecutor = context.compatMainExecutor

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
@@ -23,6 +23,7 @@ import androidx.core.util.Consumer
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import com.ujizin.camposer.extensions.compatMainExecutor
+import com.ujizin.camposer.extensions.findLifecycleOwner
 import java.util.concurrent.Executor
 
 /**
@@ -36,7 +37,7 @@ import java.util.concurrent.Executor
 internal class CameraXControllerWrapper(
   context: Context,
 ) : CameraXController {
-  override val lifecycleOwner = (context as LifecycleOwner)
+  override val lifecycleOwner = context.findLifecycleOwner()
 
   override val contentResolver: ContentResolver = context.contentResolver
 

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/extensions/ContextExtensions.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/extensions/ContextExtensions.kt
@@ -1,11 +1,9 @@
 package com.ujizin.camposer.extensions
 
 import android.content.Context
-import android.content.ContextWrapper
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import androidx.lifecycle.LifecycleOwner
 import java.util.concurrent.Executor
 
 private class MainThreadExecutor(
@@ -22,13 +20,6 @@ private class MainThreadExecutor(
     handler.post(r)
   }
 }
-
-internal tailrec fun Context.findLifecycleOwner(): LifecycleOwner =
-  when (this) {
-    is LifecycleOwner -> this
-    is ContextWrapper -> baseContext.findLifecycleOwner()
-    else -> error("No LifecycleOwner found in Context chain")
-  }
 
 internal val Context.compatMainExecutor: Executor
   get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/extensions/ContextExtensions.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/extensions/ContextExtensions.kt
@@ -1,9 +1,11 @@
 package com.ujizin.camposer.extensions
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import androidx.lifecycle.LifecycleOwner
 import java.util.concurrent.Executor
 
 private class MainThreadExecutor(
@@ -20,6 +22,13 @@ private class MainThreadExecutor(
     handler.post(r)
   }
 }
+
+internal tailrec fun Context.findLifecycleOwner(): LifecycleOwner =
+  when (this) {
+    is LifecycleOwner -> this
+    is ContextWrapper -> baseContext.findLifecycleOwner()
+    else -> error("No LifecycleOwner found in Context chain")
+  }
 
 internal val Context.compatMainExecutor: Executor
   get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
@@ -63,11 +63,12 @@ public actual class CameraSession internal constructor(
 
   public constructor(
     context: Context,
+    lifecycleOwner: LifecycleOwner,
     cameraController: CameraController,
   ) : this(
     context = context,
     cameraController = cameraController,
-    cameraXController = CameraXControllerWrapper(context),
+    cameraXController = CameraXControllerWrapper(context, lifecycleOwner),
   )
 
   internal constructor(

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSessionState.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSessionState.android.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.ujizin.camposer.CameraPreview
 import com.ujizin.camposer.controller.camera.CameraController
 import com.ujizin.camposer.state.properties.ImageAnalysisBackpressureStrategy
@@ -18,7 +19,8 @@ import com.ujizin.camposer.state.properties.ImageAnalyzer
 @Composable
 public actual fun rememberCameraSession(controller: CameraController): CameraSession {
   val context = LocalContext.current
-  val cameraSession = remember(controller) { CameraSession(context, controller) }
+  val lifecycleOwner = LocalLifecycleOwner.current
+  val cameraSession = remember(controller) { CameraSession(context, lifecycleOwner, controller) }
   DisposableEffect(cameraSession) { onDispose(cameraSession::dispose) }
   return cameraSession
 }

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSessionState.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSessionState.android.kt
@@ -20,7 +20,8 @@ import com.ujizin.camposer.state.properties.ImageAnalyzer
 public actual fun rememberCameraSession(controller: CameraController): CameraSession {
   val context = LocalContext.current
   val lifecycleOwner = LocalLifecycleOwner.current
-  val cameraSession = remember(controller) { CameraSession(context, lifecycleOwner, controller) }
+  val cameraSession =
+    remember(controller, lifecycleOwner) { CameraSession(context, lifecycleOwner, controller) }
   DisposableEffect(cameraSession) { onDispose(cameraSession::dispose) }
   return cameraSession
 }


### PR DESCRIPTION
## Issue

#88 

## Summary

Fix crash when initialize camera session by walking up context wrapper until finds lifecycle owner

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / tooling

## Checklist

- [X] Code formatted (Spotless)
- [X] Build passes
- [X] No unintentional public API changes
- [ ] Tests written or updated

## Testing notes

- Device & Emulator


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android camera lifecycle management by requiring explicit LifecycleOwner parameter during CameraSession initialization, enhancing stability.

* **Tests**
  * Updated Android test emulator configuration for API level 23 (x86) to use google_apis target for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->