### PR TITLE
fix(ios): remove capture inputs/outputs from session before stopping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ site
 
 # AI agent review output
 .agents/reviews/*
+.agents/settings.local.json
+
+# Git worktrees
+.worktrees

--- a/camposer/api/camposer.klib.api
+++ b/camposer/api/camposer.klib.api
@@ -184,6 +184,7 @@ abstract interface com.ujizin.camposer.internal.core.ios/IOSCameraController { /
         abstract fun <get-zoomRange>(): kotlin/Pair<kotlin/Float, kotlin/Float> // com.ujizin.camposer.internal.core.ios/IOSCameraController.zoomRange.<get-zoomRange>|<get-zoomRange>(){}[0]
 
     abstract fun addOutput(platform.AVFoundation/AVCaptureOutput) // com.ujizin.camposer.internal.core.ios/IOSCameraController.addOutput|addOutput(platform.AVFoundation.AVCaptureOutput){}[0]
+    abstract fun detachPreviewLayer() // com.ujizin.camposer.internal.core.ios/IOSCameraController.detachPreviewLayer|detachPreviewLayer(){}[0]
     abstract fun getCaptureDevice(kotlin.collections/List<kotlin/String?>, kotlin/Long, kotlin/String? = ...): platform.AVFoundation/AVCaptureDevice? // com.ujizin.camposer.internal.core.ios/IOSCameraController.getCaptureDevice|getCaptureDevice(kotlin.collections.List<kotlin.String?>;kotlin.Long;kotlin.String?){}[0]
     abstract fun getCurrentDeviceOrientation(): kotlin/Long // com.ujizin.camposer.internal.core.ios/IOSCameraController.getCurrentDeviceOrientation|getCurrentDeviceOrientation(){}[0]
     abstract fun getCurrentPosition(): kotlin/Long // com.ujizin.camposer.internal.core.ios/IOSCameraController.getCurrentPosition|getCurrentPosition(){}[0]
@@ -440,6 +441,7 @@ final class com.ujizin.camposer.session/DefaultIOSCameraController : com.ujizin.
         final fun <get-zoomRange>(): kotlin/Pair<kotlin/Float, kotlin/Float> // com.ujizin.camposer.session/DefaultIOSCameraController.zoomRange.<get-zoomRange>|<get-zoomRange>(){}[0]
 
     final fun addOutput(platform.AVFoundation/AVCaptureOutput) // com.ujizin.camposer.session/DefaultIOSCameraController.addOutput|addOutput(platform.AVFoundation.AVCaptureOutput){}[0]
+    final fun detachPreviewLayer() // com.ujizin.camposer.session/DefaultIOSCameraController.detachPreviewLayer|detachPreviewLayer(){}[0]
     final fun getCaptureDevice(kotlin.collections/List<kotlin/String?>, kotlin/Long, kotlin/String?): platform.AVFoundation/AVCaptureDevice? // com.ujizin.camposer.session/DefaultIOSCameraController.getCaptureDevice|getCaptureDevice(kotlin.collections.List<kotlin.String?>;kotlin.Long;kotlin.String?){}[0]
     final fun getCurrentDeviceOrientation(): kotlin/Long // com.ujizin.camposer.session/DefaultIOSCameraController.getCurrentDeviceOrientation|getCurrentDeviceOrientation(){}[0]
     final fun getCurrentPosition(): kotlin/Long // com.ujizin.camposer.session/DefaultIOSCameraController.getCurrentPosition|getCurrentPosition(){}[0]

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/CameraPreview.ios.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/CameraPreview.ios.kt
@@ -1,6 +1,7 @@
 package com.ujizin.camposer
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -47,39 +48,42 @@ internal actual fun CameraPreviewImpl(
   val backgroundColor = remember(previewBackgroundColor) {
     previewBackgroundColor.toUIColor()
   }
-  UIKitViewController(
-    modifier = modifier,
-    factory = {
-      CameraViewController(
-        cameraSession = cameraSession,
-        cameraViewDelegate = object : CameraViewDelegate {
-          override fun onFocusTap(
-            x: Float,
-            y: Float,
-          ): Unit =
-            with(density) {
-              onTapFocus(Offset(x.dp.toPx(), y.dp.toPx()))
-            }
-        },
-      )
-    },
-    update = { cameraViewController ->
-      val session = cameraViewController.cameraSession
-      session.updatePreviewBackgroundColor(backgroundColor)
-      session.update(
-        camSelector = camSelector,
-        captureMode = captureMode,
-        camFormat = camFormat,
-        scaleType = scaleType,
-        isImageAnalysisEnabled = isImageAnalysisEnabled,
-        imageAnalyzer = imageAnalyzer,
-        implementationMode = implementationMode,
-        isFocusOnTapEnabled = isFocusOnTapEnabled,
-        imageCaptureStrategy = imageCaptureStrategy,
-        isPinchToZoomEnabled = isPinchToZoomEnabled,
-      )
-    },
-  )
+
+  key(cameraSession) {
+    UIKitViewController(
+      modifier = modifier,
+      factory = {
+        CameraViewController(
+          cameraSession = cameraSession,
+          cameraViewDelegate = object : CameraViewDelegate {
+            override fun onFocusTap(
+              x: Float,
+              y: Float,
+            ): Unit =
+              with(density) {
+                onTapFocus(Offset(x.dp.toPx(), y.dp.toPx()))
+              }
+          },
+        )
+      },
+      update = { cameraViewController ->
+        val session = cameraViewController.cameraSession
+        session.updatePreviewBackgroundColor(backgroundColor)
+        session.update(
+          camSelector = camSelector,
+          captureMode = captureMode,
+          camFormat = camFormat,
+          scaleType = scaleType,
+          isImageAnalysisEnabled = isImageAnalysisEnabled,
+          imageAnalyzer = imageAnalyzer,
+          implementationMode = implementationMode,
+          isFocusOnTapEnabled = isFocusOnTapEnabled,
+          imageCaptureStrategy = imageCaptureStrategy,
+          isPinchToZoomEnabled = isPinchToZoomEnabled,
+        )
+      },
+    )
+  }
 
   content()
 }

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/core/applier/SessionTopologyApplier.ios.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/core/applier/SessionTopologyApplier.ios.kt
@@ -2,15 +2,16 @@ package com.ujizin.camposer.internal.core.applier
 
 import com.ujizin.camposer.info.CameraInfo
 import com.ujizin.camposer.internal.core.ios.IOSCameraController
+import com.ujizin.camposer.internal.extensions.firstIsInstanceOrNull
 import com.ujizin.camposer.state.CameraState
 import com.ujizin.camposer.state.properties.CaptureMode
 import com.ujizin.camposer.state.properties.FlashMode
 import com.ujizin.camposer.state.properties.ImageCaptureStrategy
 import com.ujizin.camposer.state.properties.VideoStabilizationMode
+import com.ujizin.camposer.state.properties.createOutput
 import com.ujizin.camposer.state.properties.format.CamFormat
 import com.ujizin.camposer.state.properties.highResolutionEnabled
 import com.ujizin.camposer.state.properties.mode
-import com.ujizin.camposer.state.properties.output
 import com.ujizin.camposer.state.properties.quality
 import com.ujizin.camposer.state.properties.selector.CamSelector
 import com.ujizin.camposer.state.properties.selector.getCaptureDevice
@@ -21,7 +22,9 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import platform.AVFoundation.AVCaptureMovieFileOutput
 import platform.AVFoundation.AVCaptureOutput
+import platform.AVFoundation.AVCapturePhotoOutput
 
 internal class SessionTopologyApplier(
   private val cameraState: CameraState,
@@ -57,8 +60,8 @@ internal class SessionTopologyApplier(
     captureMode: CaptureMode,
   ) {
     iOSCameraController.withSessionConfiguration {
-      iOSCameraController.removeOutput(previousCaptureMode.output)
-      iOSCameraController.addOutput(captureMode.output)
+      previousCaptureMode.findOutput()?.let { iOSCameraController.removeOutput(it) }
+      iOSCameraController.addOutput(captureMode.createOutput())
       updateConfig(captureMode = captureMode, captureModeChanged = true)
     }
     cameraState.updateCaptureMode(captureMode)
@@ -90,7 +93,9 @@ internal class SessionTopologyApplier(
     camFormat.applyConfigs(
       cameraInfo = cameraInfo,
       iosCameraController = iOSCameraController,
-      onDeviceFormatUpdated = { cameraInfo.rebind(output = captureMode.output) },
+      onDeviceFormatUpdated = {
+        captureMode.findOutput()?.let { cameraInfo.rebind(output = it) }
+      },
       onStabilizationModeChanged = {
         setVideoStabilizationMode(it)
         cameraState.updateVideoStabilizationMode(it)
@@ -157,7 +162,7 @@ internal class SessionTopologyApplier(
     captureModeChanged: Boolean = false,
     camSelectorChanged: Boolean = false,
   ) {
-    resetConfig(captureMode.output)
+    captureMode.findOutput()?.let { resetConfig(it) }
 
     if (captureModeChanged || camSelectorChanged) {
       setCamFormat(
@@ -166,6 +171,17 @@ internal class SessionTopologyApplier(
       )
     }
   }
+
+  private fun CaptureMode.findOutput(): AVCaptureOutput? =
+    when (this) {
+      CaptureMode.Image -> {
+        iOSCameraController.captureSession.outputs.firstIsInstanceOrNull<AVCapturePhotoOutput>()
+      }
+
+      CaptureMode.Video -> {
+        iOSCameraController.captureSession.outputs.firstIsInstanceOrNull<AVCaptureMovieFileOutput>()
+      }
+    }
 
   private fun lockedLaunch(block: suspend CoroutineScope.() -> Unit): Job =
     cameraState.launch {

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/core/ios/IOSCameraController.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/core/ios/IOSCameraController.kt
@@ -132,4 +132,6 @@ public interface IOSCameraController {
   public fun muteRecording(isMuted: Boolean): Result<Boolean>
 
   public fun release()
+
+  public fun detachPreviewLayer()
 }

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/view/CameraViewController.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/view/CameraViewController.kt
@@ -1,5 +1,6 @@
 package com.ujizin.camposer.internal.view
 
+import com.ujizin.camposer.internal.utils.DispatchQueue.cameraQueue
 import com.ujizin.camposer.internal.view.gesture.PinchToZoomGestureHandler
 import com.ujizin.camposer.internal.view.gesture.TapToFocusGestureHandler
 import com.ujizin.camposer.session.CameraSession
@@ -10,6 +11,7 @@ import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSSelectorFromString
 import platform.UIKit.UIApplicationDidBecomeActiveNotification
 import platform.UIKit.UIViewController
+import platform.darwin.dispatch_async
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 internal class CameraViewController(
@@ -29,10 +31,16 @@ internal class CameraViewController(
 
   override fun viewDidLoad() {
     super.viewDidLoad()
-    observeAppLifecycle()
     addCameraGesturesRecognizer()
+  }
 
-    cameraSession.startCamera()
+  override fun viewWillAppear(animated: Boolean) {
+    super.viewWillAppear(animated)
+    observeAppLifecycle()
+    cameraSession.renderCamera(view)
+    dispatch_async(cameraQueue) {
+      cameraSession.startCamera()
+    }
   }
 
   override fun viewDidLayoutSubviews() {
@@ -57,12 +65,14 @@ internal class CameraViewController(
 
   @ObjCAction
   fun appDidBecomeActive() {
-    cameraSession.recoveryState()
+    dispatch_async(cameraQueue) {
+      cameraSession.recoveryState()
+    }
   }
 
   override fun viewDidDisappear(animated: Boolean) {
     NSNotificationCenter.defaultCenter.removeObserver(this)
-    cameraSession.dispose()
+    cameraSession.detachView()
     super.viewDidDisappear(animated)
   }
 }

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/view/gesture/PinchToZoomGestureHandler.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/view/gesture/PinchToZoomGestureHandler.kt
@@ -22,6 +22,7 @@ internal class PinchToZoomGestureHandler(
   @OptIn(BetaInteropApi::class)
   @ObjCAction
   internal fun onPinch(sender: UIPinchGestureRecognizer) {
+    if (!cameraSession.isStreaming) return
     if (!cameraSession.state.isPinchToZoomEnabled.value ||
       sender.state != UIGestureRecognizerStateChanged
     ) {

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/view/gesture/TapToFocusGestureHandler.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/view/gesture/TapToFocusGestureHandler.kt
@@ -25,6 +25,7 @@ internal class TapToFocusGestureHandler(
 
   @ObjCAction
   internal fun onTap(sender: UITapGestureRecognizer) {
+    if (!cameraSession.isStreaming) return
     val cameraInfo = cameraSession.info.state.value
     if (!cameraInfo.isFocusSupported || !cameraSession.state.isFocusOnTapEnabled.value) {
       return

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/manager/PreviewManager.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/manager/PreviewManager.kt
@@ -11,6 +11,8 @@ import platform.UIKit.UIColor
 import platform.UIKit.UIDeviceOrientationDidChangeNotification
 import platform.UIKit.UIView
 import platform.darwin.NSObjectProtocol
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 @OptIn(ExperimentalForeignApi::class)
 internal class PreviewManager(
@@ -24,21 +26,27 @@ internal class PreviewManager(
 
   private var orientationObserver: NSObjectProtocol? = null
 
-  internal fun start(avCaptureSession: AVCaptureSession) =
-    with(videoPreviewLayer) {
-      setSession(avCaptureSession)
+  internal fun start(avCaptureSession: AVCaptureSession) {
+    videoPreviewLayer.setSession(avCaptureSession)
+    dispatch_async(dispatch_get_main_queue()) {
+      updateOrientation()
     }
+  }
 
   internal fun attachView(view: UIView) =
     with(videoPreviewLayer) {
-      view.layer.addSublayer(this)
+      if (superlayer == null) {
+        view.layer.addSublayer(this)
+      }
       setFrame(view.bounds)
 
-      orientationObserver = notificationCenter.addObserverForName(
-        UIDeviceOrientationDidChangeNotification,
-        null,
-        null,
-      ) { updateOrientation() }
+      if (orientationObserver == null) {
+        orientationObserver = notificationCenter.addObserverForName(
+          UIDeviceOrientationDidChangeNotification,
+          null,
+          null,
+        ) { updateOrientation() }
+      }
 
       updateOrientation()
       setVideoGravity(currentGravity)
@@ -61,6 +69,7 @@ internal class PreviewManager(
 
   internal fun detachView() {
     orientationObserver?.let(notificationCenter::removeObserver)
+    orientationObserver = null
     videoPreviewLayer.removeFromSuperlayer()
   }
 }

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/CameraSession.ios.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/CameraSession.ios.kt
@@ -13,6 +13,7 @@ import com.ujizin.camposer.internal.core.CameraEngine
 import com.ujizin.camposer.internal.core.CameraEngineImpl
 import com.ujizin.camposer.internal.core.IOSCameraEngine
 import com.ujizin.camposer.internal.core.ios.IOSCameraController
+import com.ujizin.camposer.internal.utils.DispatchQueue.cameraQueue
 import com.ujizin.camposer.internal.utils.Logger
 import com.ujizin.camposer.manager.PreviewManager
 import com.ujizin.camposer.state.CameraState
@@ -24,6 +25,7 @@ import platform.AVFoundation.AVCaptureSession
 import platform.CoreGraphics.CGPoint
 import platform.UIKit.UIColor
 import platform.UIKit.UIView
+import platform.darwin.dispatch_async
 
 @OptIn(ExperimentalForeignApi::class)
 @Stable
@@ -104,12 +106,14 @@ public actual class CameraSession internal constructor(
   }
 
   @OptIn(ExperimentalForeignApi::class)
-  internal fun startCamera() =
+  internal fun startCamera() {
+    if (iosCameraController.captureSession.isRunning()) return
     iosCameraController.start(
       captureOutput = state.captureMode.value.createOutput(),
       device = iosCameraController.getCaptureDevice(state.camSelector.value),
       onRunningChanged = { isStreaming = it },
     )
+  }
 
   internal fun renderCamera(view: UIView) {
     iosCameraController.renderPreviewLayer(view = view)
@@ -126,9 +130,15 @@ public actual class CameraSession internal constructor(
     iosCameraController.setPreviewBackgroundColor(uiColor)
   }
 
+  internal fun detachView() {
+    iosCameraController.detachPreviewLayer()
+  }
+
   internal fun dispose() {
-    state.dispose()
-    controller.dispose()
-    iosCameraController.release()
+    dispatch_async(cameraQueue) {
+      state.dispose()
+      controller.dispose()
+      iosCameraController.release()
+    }
   }
 }

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/CameraSession.ios.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/CameraSession.ios.kt
@@ -16,7 +16,7 @@ import com.ujizin.camposer.internal.core.ios.IOSCameraController
 import com.ujizin.camposer.internal.utils.Logger
 import com.ujizin.camposer.manager.PreviewManager
 import com.ujizin.camposer.state.CameraState
-import com.ujizin.camposer.state.properties.output
+import com.ujizin.camposer.state.properties.createOutput
 import com.ujizin.camposer.state.properties.selector.getCaptureDevice
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -78,7 +78,7 @@ public actual class CameraSession internal constructor(
         setCaptureDevice(
           device = iosCameraController.getCaptureDevice(state.camSelector.value),
         )
-        info.rebind(state.captureMode.value.output)
+        info.rebind(state.captureMode.value.createOutput())
         isInitialized = true
       }
     }.onFailure { error ->
@@ -106,7 +106,7 @@ public actual class CameraSession internal constructor(
   @OptIn(ExperimentalForeignApi::class)
   internal fun startCamera() =
     iosCameraController.start(
-      captureOutput = state.captureMode.value.output,
+      captureOutput = state.captureMode.value.createOutput(),
       device = iosCameraController.getCaptureDevice(state.camSelector.value),
       onRunningChanged = { isStreaming = it },
     )

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/CameraSessionState.ios.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/CameraSessionState.ios.kt
@@ -8,6 +8,6 @@ import com.ujizin.camposer.controller.camera.CameraController
 @Composable
 public actual fun rememberCameraSession(controller: CameraController): CameraSession {
   val session = remember(controller) { CameraSession(controller) }
-  DisposableEffect(Unit) { onDispose(session::dispose) }
+  DisposableEffect(session) { onDispose(session::dispose) }
   return session
 }

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/DefaultIOSCameraController.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/DefaultIOSCameraController.kt
@@ -82,6 +82,7 @@ import platform.UIKit.UIColor
 import platform.UIKit.UIView
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async
+import platform.darwin.dispatch_sync
 import platform.foundation.NSKeyValueObservingProtocol
 
 @OptIn(ExperimentalForeignApi::class)
@@ -478,11 +479,13 @@ public class DefaultIOSCameraController internal constructor(
     runningObserver = null
     orientationListener.stop()
     _captureDeviceInput = null
-    withSessionConfiguration {
-      captureSession.outputs.forEach { captureSession.removeOutput(it as AVCaptureOutput) }
-      captureSession.inputs.forEach { captureSession.removeInput(it as AVCaptureInput) }
+    dispatch_sync(cameraQueue) {
+      withSessionConfiguration {
+        captureSession.outputs.forEach { captureSession.removeOutput(it as AVCaptureOutput) }
+        captureSession.inputs.forEach { captureSession.removeInput(it as AVCaptureInput) }
+      }
+      captureSession.stopRunning()
     }
-    captureSession.stopRunning()
     previewManager.detachView()
   }
 

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/DefaultIOSCameraController.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/DefaultIOSCameraController.kt
@@ -33,6 +33,7 @@ import platform.AVFoundation.AVCaptureExposureModeContinuousAutoExposure
 import platform.AVFoundation.AVCaptureFlashMode
 import platform.AVFoundation.AVCaptureFocusModeAutoFocus
 import platform.AVFoundation.AVCaptureFocusModeContinuousAutoFocus
+import platform.AVFoundation.AVCaptureInput
 import platform.AVFoundation.AVCaptureMovieFileOutput
 import platform.AVFoundation.AVCaptureOutput
 import platform.AVFoundation.AVCapturePhotoOutput
@@ -477,6 +478,10 @@ public class DefaultIOSCameraController internal constructor(
     runningObserver = null
     orientationListener.stop()
     _captureDeviceInput = null
+    withSessionConfiguration {
+      captureSession.outputs.forEach { captureSession.removeOutput(it as AVCaptureOutput) }
+      captureSession.inputs.forEach { captureSession.removeInput(it as AVCaptureInput) }
+    }
     captureSession.stopRunning()
     previewManager.detachView()
   }

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/DefaultIOSCameraController.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/session/DefaultIOSCameraController.kt
@@ -12,7 +12,6 @@ import com.ujizin.camposer.internal.extensions.toDeviceInput
 import com.ujizin.camposer.internal.extensions.tryAddInput
 import com.ujizin.camposer.internal.extensions.tryAddOutput
 import com.ujizin.camposer.internal.extensions.withConfigurationLock
-import com.ujizin.camposer.internal.utils.DispatchQueue.cameraQueue
 import com.ujizin.camposer.manager.PreviewManager
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.COpaquePointer
@@ -81,8 +80,6 @@ import platform.Foundation.removeObserver
 import platform.UIKit.UIColor
 import platform.UIKit.UIView
 import platform.darwin.NSObject
-import platform.darwin.dispatch_async
-import platform.darwin.dispatch_sync
 import platform.foundation.NSKeyValueObservingProtocol
 
 @OptIn(ExperimentalForeignApi::class)
@@ -194,42 +191,41 @@ public class DefaultIOSCameraController internal constructor(
     captureOutput: AVCaptureOutput,
     device: AVCaptureDevice,
     onRunningChanged: (Boolean) -> Unit,
-  ): Unit =
-    dispatch_async(cameraQueue) {
-      captureSession.beginConfiguration()
+  ) {
+    captureSession.beginConfiguration()
 
-      setCaptureDevice(device)
-      captureSession.tryAddOutput(captureOutput)
-      captureSession.commitConfiguration()
+    setCaptureDevice(device)
+    captureSession.tryAddOutput(captureOutput)
+    captureSession.commitConfiguration()
 
-      previewManager.start(captureSession)
+    previewManager.start(captureSession)
 
-      runningObserver?.let {
-        captureSession.removeObserver(it, RUNNING_KEY_PATH)
-      }
-
-      val runningObserver = object : NSObject(), NSKeyValueObservingProtocol {
-        override fun observeValueForKeyPath(
-          keyPath: String?,
-          ofObject: Any?,
-          change: Map<Any?, *>?,
-          context: COpaquePointer?,
-        ) {
-          onRunningChanged(change?.get(NSKeyValueChangeNewKey) as? Boolean == true)
-        }
-      }.also { runningObserver = it }
-
-      captureSession.addObserver(
-        observer = runningObserver,
-        forKeyPath = RUNNING_KEY_PATH,
-        options = NSKeyValueObservingOptionNew,
-        context = null,
-      )
-
-      orientationListener.start()
-      captureSession.startRunning()
-      onRunningChanged(captureSession.isRunning())
+    runningObserver?.let {
+      captureSession.removeObserver(it, RUNNING_KEY_PATH)
     }
+
+    val runningObserver = object : NSObject(), NSKeyValueObservingProtocol {
+      override fun observeValueForKeyPath(
+        keyPath: String?,
+        ofObject: Any?,
+        change: Map<Any?, *>?,
+        context: COpaquePointer?,
+      ) {
+        onRunningChanged(change?.get(NSKeyValueChangeNewKey) as? Boolean == true)
+      }
+    }.also { runningObserver = it }
+
+    captureSession.addObserver(
+      observer = runningObserver,
+      forKeyPath = RUNNING_KEY_PATH,
+      options = NSKeyValueObservingOptionNew,
+      context = null,
+    )
+
+    orientationListener.start()
+    captureSession.startRunning()
+    onRunningChanged(captureSession.isRunning())
+  }
 
   override fun getCurrentDeviceOrientation(): AVCaptureVideoOrientation =
     orientationListener.currentOrientation
@@ -479,13 +475,14 @@ public class DefaultIOSCameraController internal constructor(
     runningObserver = null
     orientationListener.stop()
     _captureDeviceInput = null
-    dispatch_sync(cameraQueue) {
-      withSessionConfiguration {
-        captureSession.outputs.forEach { captureSession.removeOutput(it as AVCaptureOutput) }
-        captureSession.inputs.forEach { captureSession.removeInput(it as AVCaptureInput) }
-      }
-      captureSession.stopRunning()
+    withSessionConfiguration {
+      captureSession.outputs.forEach { captureSession.removeOutput(it as AVCaptureOutput) }
+      captureSession.inputs.forEach { captureSession.removeInput(it as AVCaptureInput) }
     }
+    captureSession.stopRunning()
+  }
+
+  override fun detachPreviewLayer() {
     previewManager.detachView()
   }
 

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/state/properties/CaptureMode.ios.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/state/properties/CaptureMode.ios.kt
@@ -4,11 +4,8 @@ import platform.AVFoundation.AVCaptureMovieFileOutput
 import platform.AVFoundation.AVCaptureOutput
 import platform.AVFoundation.AVCapturePhotoOutput
 
-private val photoOutput: AVCaptureOutput = AVCapturePhotoOutput()
-private val videoOutput: AVCaptureOutput = AVCaptureMovieFileOutput()
-
-internal val CaptureMode.output: AVCaptureOutput
-  get() = when (this) {
-    CaptureMode.Image -> photoOutput
-    CaptureMode.Video -> videoOutput
+internal fun CaptureMode.createOutput(): AVCaptureOutput =
+  when (this) {
+    CaptureMode.Image -> AVCapturePhotoOutput()
+    CaptureMode.Video -> AVCaptureMovieFileOutput()
   }

--- a/camposer/src/iosTest/kotlin/com/ujizin/camposer/fake/FakeCameraTest.ios.kt
+++ b/camposer/src/iosTest/kotlin/com/ujizin/camposer/fake/FakeCameraTest.ios.kt
@@ -9,12 +9,12 @@ import com.ujizin.camposer.state.properties.ImageCaptureStrategy
 import com.ujizin.camposer.state.properties.format.CamFormat
 import com.ujizin.camposer.state.properties.highResolutionEnabled
 import com.ujizin.camposer.state.properties.mode
-import com.ujizin.camposer.state.properties.output
 import com.ujizin.camposer.state.properties.quality
 import com.ujizin.camposer.state.properties.selector.CamSelector
 import com.ujizin.camposer.state.properties.selector.value
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import platform.AVFoundation.AVCaptureMovieFileOutput
+import platform.AVFoundation.AVCapturePhotoOutput
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -63,10 +63,14 @@ internal actual class FakeCameraTest(
   }
 
   actual fun assertCaptureMode(expected: CaptureMode) {
-    val outputs = fakeIosCameraController.fakeOutputs
+    val lastOutput = fakeIosCameraController.fakeOutputs.lastOrNull()
+    val matchesType = when (expected) {
+      CaptureMode.Image -> lastOutput is AVCapturePhotoOutput
+      CaptureMode.Video -> lastOutput is AVCaptureMovieFileOutput
+    }
     assertTrue(
-      message = "Expected output to be $expected (${expected.output}), outputs: $outputs",
-      actual = outputs.contains(expected.output),
+      message = "Expected capture mode $expected, last output: $lastOutput",
+      actual = matchesType,
     )
   }
 

--- a/camposer/src/iosTest/kotlin/com/ujizin/camposer/fake/FakeIosCameraController.kt
+++ b/camposer/src/iosTest/kotlin/com/ujizin/camposer/fake/FakeIosCameraController.kt
@@ -77,8 +77,7 @@ class FakeIosCameraController : IOSCameraController {
 
   private var position: AVCaptureDevicePosition = AVCaptureDevicePositionUnspecified
 
-  override val captureSession: AVCaptureSession
-    get() = AVCaptureSession()
+  override val captureSession: AVCaptureSession = AVCaptureSession()
 
   override val captureDeviceInput: AVCaptureDeviceInput
     get() = TODO("Not yet implemented")
@@ -265,5 +264,9 @@ class FakeIosCameraController : IOSCameraController {
 
   override fun release() {
     isFakeReleased = true
+  }
+
+  override fun detachPreviewLayer() {
+    // no-op
   }
 }

--- a/camposer/src/iosTest/kotlin/com/ujizin/camposer/internal/controller/IOSRecordControllerTest.kt
+++ b/camposer/src/iosTest/kotlin/com/ujizin/camposer/internal/controller/IOSRecordControllerTest.kt
@@ -251,5 +251,7 @@ private class TestIOSCameraController(
     return Result.success(isMuted)
   }
 
+  override fun detachPreviewLayer() = Unit
+
   override fun release() = Unit
 }


### PR DESCRIPTION
## Issue

#91

## Summary

Fixes an issue where AVFoundation could throw "output not found" errors when the camera session was disposed before outputs were properly removed. The fix removes all capture inputs and outputs from the session within a configuration block before calling `stopRunning()`, ensuring clean teardown of the capture pipeline.

Also adds `.worktrees` directory and `settings.local.json` to `.gitignore`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / tooling

## Checklist

- [x] Code formatted (Spotless)
- [x] Build passes
- [x] No unintentional public API changes
- [ ] Tests written or updated

## Testing notes

- **Platform:** iOS (simulator and device)
- Verify camera preview starts and stops without "output not found" errors in console
- Test rapid open/close cycles of the camera to trigger the race condition
- No Android changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to detach the iOS preview layer via the camera controller abstraction.
* **Bug Fixes**
  * Improved iOS camera startup/shutdown threading and strengthened teardown cleanup (ordered input/output removal, safer session stop).
  * Fixed capture-mode switching by rebinding the active photo/video output from what’s currently attached to the session.
  * Enhanced preview lifecycle (main-thread orientation updates, prevents duplicate preview layers/observers) and gesture handling (tap-to-focus/pinch-to-zoom disabled when not streaming).
* **Tests**
  * Updated iOS test doubles and assertions to match the new output handling.
* **Chores**
  * Expanded ignore rules for local agent config and git worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->