### PR TITLE
fix(android): remove explicit unbind to prevent dark screen on navigation

### DIFF
--- a/camposer/src/androidDeviceTest/kotlin/com/ujizin/camposer/fake/FakeCameraXController.kt
+++ b/camposer/src/androidDeviceTest/kotlin/com/ujizin/camposer/fake/FakeCameraXController.kt
@@ -265,6 +265,10 @@ internal class FakeCameraXController : CameraXController {
     bindCount++
   }
 
+  override fun dispose() {
+    // no-op
+  }
+
   private fun createRecording(
     outputUri: Uri,
     consumerEvent: Consumer<RecordEvent>,

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/CameraPreview.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/CameraPreview.android.kt
@@ -83,39 +83,38 @@ internal actual fun CameraPreviewImpl(
 
   LaunchedEffect(latestBitmap) { latestBitmap?.let(onSwitchCamera) }
 
-  LaunchedEffect(cameraSession) {
-    val previewView = cameraSession.previewView ?: return@LaunchedEffect
-    if (cameraSession.cameraXControllerWrapper.isCameraControllerEquals(
-        previewView.controller,
-      )
-    ) {
-      return@LaunchedEffect
-    }
-
-    previewView.onViewBind(
-      cameraSession = cameraSession,
-      lifecycleOwner = lifecycleOwner,
-      onTapFocus = {
-        val cameraInfoState = cameraSession.info.state.value
-        if (cameraInfoState.isFocusSupported &&
-          cameraSession.state.isFocusOnTapEnabled.value
-        ) {
-          onTapFocus(it + cameraOffset)
-        }
-      },
-    )
-  }
-
   AndroidView(
     modifier = modifier.onGloballyPositioned { cameraOffset = it.positionInParent() },
-    factory = {
-      PreviewView(it).apply {
+    factory = { context ->
+      PreviewView(context).apply {
         cameraSession.previewView = this
         this.scaleType = scaleType.type
         this.implementationMode = implementationMode.value
       }
     },
     update = { previewView ->
+      if (cameraSession.previewView !== previewView) {
+        cameraSession.previewView = previewView
+      }
+
+      if (!cameraSession.cameraXControllerWrapper.isCameraControllerEquals(
+          previewView.controller,
+        )
+      ) {
+        previewView.onViewBind(
+          cameraSession = cameraSession,
+          lifecycleOwner = lifecycleOwner,
+          onTapFocus = {
+            val cameraInfoState = cameraSession.info.state.value
+            if (cameraInfoState.isFocusSupported &&
+              cameraSession.state.isFocusOnTapEnabled.value
+            ) {
+              onTapFocus(it + cameraOffset)
+            }
+          },
+        )
+      }
+
       if (!cameraIsInitialized) return@AndroidView
       with(previewView) {
         if (this.scaleType != scaleType.type ||

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/CameraLifecycleOwner.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/CameraLifecycleOwner.kt
@@ -40,7 +40,7 @@ internal class CameraLifecycleOwner(
 
   fun dispose() {
     parent.lifecycle.removeObserver(parentObserver)
-    if (registry.currentState != Lifecycle.State.DESTROYED) {
+    if (registry.currentState.isAtLeast(Lifecycle.State.CREATED)) {
       registry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     }
   }

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/CameraLifecycleOwner.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/CameraLifecycleOwner.kt
@@ -1,0 +1,47 @@
+package com.ujizin.camposer.internal
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+/**
+ * A per-session [LifecycleOwner] that mirrors a parent lifecycle but can be
+ * independently destroyed.
+ *
+ * CameraX's [androidx.camera.view.LifecycleCameraController.unbind] internally
+ * calls [androidx.camera.core.CameraX]'s `ProcessCameraProvider.unbindAll()`,
+ * which is a **process-wide** operation that tears down every camera session.
+ * By binding each camera controller to its own [CameraLifecycleOwner] instead
+ * of the Activity/Fragment lifecycle, disposing one session only destroys its
+ * child lifecycle — and `ProcessCameraProvider` unbinds only the use cases
+ * that were bound to that specific owner, leaving other sessions intact.
+ */
+internal class CameraLifecycleOwner(
+  private val parent: LifecycleOwner,
+) : LifecycleOwner {
+  private val registry = LifecycleRegistry(this)
+
+  private val parentObserver = LifecycleEventObserver { _, event ->
+    if (registry.currentState != Lifecycle.State.DESTROYED) {
+      registry.handleLifecycleEvent(event)
+    }
+  }
+
+  init {
+    val parentState = parent.lifecycle.currentState
+    if (parentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
+      registry.currentState = parentState
+      parent.lifecycle.addObserver(parentObserver)
+    }
+  }
+
+  override val lifecycle: Lifecycle get() = registry
+
+  fun dispose() {
+    parent.lifecycle.removeObserver(parentObserver)
+    if (registry.currentState != Lifecycle.State.DESTROYED) {
+      registry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    }
+  }
+}

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXController.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXController.kt
@@ -97,5 +97,7 @@ internal interface CameraXController {
 
   fun bindToLifecycle(lifecycle: LifecycleOwner)
 
+  fun dispose()
+
   fun attachPreview(view: PreviewView)
 }

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
@@ -133,10 +133,6 @@ internal class CameraXControllerWrapper(
     cameraXController.takePicture(outputFileOptions, mainExecutor, callback)
   }
 
-  override fun unbind() {
-    cameraXController.unbind()
-  }
-
   override fun bindToLifecycle(lifecycle: LifecycleOwner) {
     cameraXController.bindToLifecycle(lifecycle)
   }
@@ -226,4 +222,8 @@ internal class CameraXControllerWrapper(
         { consumerEvent.accept(RecordEvent(it)) },
       ),
     )
+
+  override fun unbind() {
+    cameraXController.unbind()
+  }
 }

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
@@ -23,6 +23,7 @@ import androidx.core.util.Consumer
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import com.ujizin.camposer.extensions.compatMainExecutor
+import com.ujizin.camposer.internal.CameraLifecycleOwner
 import java.util.concurrent.Executor
 
 /**
@@ -40,6 +41,8 @@ internal class CameraXControllerWrapper(
   override val contentResolver: ContentResolver = context.contentResolver
 
   override val mainExecutor = context.compatMainExecutor
+
+  private val cameraLifecycleOwner = CameraLifecycleOwner(lifecycleOwner)
 
   private val cameraXController by lazy {
     LifecycleCameraController(context)
@@ -133,8 +136,12 @@ internal class CameraXControllerWrapper(
     cameraXController.takePicture(outputFileOptions, mainExecutor, callback)
   }
 
+  // Always binds to child lifecycle regardless of caller's parameter.
+  // CameraXController interface requires the parameter, but we route all
+  // bindings through cameraLifecycleOwner so dispose() only tears down
+  // this session's use cases instead of triggering process-wide unbindAll().
   override fun bindToLifecycle(lifecycle: LifecycleOwner) {
-    cameraXController.bindToLifecycle(lifecycle)
+    cameraXController.bindToLifecycle(cameraLifecycleOwner)
   }
 
   override fun attachPreview(view: PreviewView) {
@@ -225,5 +232,9 @@ internal class CameraXControllerWrapper(
 
   override fun unbind() {
     cameraXController.unbind()
+  }
+
+  override fun dispose() {
+    cameraLifecycleOwner.dispose()
   }
 }

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/internal/core/camerax/CameraXControllerWrapper.kt
@@ -42,7 +42,7 @@ internal class CameraXControllerWrapper(
 
   override val mainExecutor = context.compatMainExecutor
 
-  private val cameraLifecycleOwner = CameraLifecycleOwner(lifecycleOwner)
+  private var cameraLifecycleOwner = CameraLifecycleOwner(lifecycleOwner)
 
   private val cameraXController by lazy {
     LifecycleCameraController(context)
@@ -136,11 +136,9 @@ internal class CameraXControllerWrapper(
     cameraXController.takePicture(outputFileOptions, mainExecutor, callback)
   }
 
-  // Always binds to child lifecycle regardless of caller's parameter.
-  // CameraXController interface requires the parameter, but we route all
-  // bindings through cameraLifecycleOwner so dispose() only tears down
-  // this session's use cases instead of triggering process-wide unbindAll().
   override fun bindToLifecycle(lifecycle: LifecycleOwner) {
+    dispose()
+    cameraLifecycleOwner = CameraLifecycleOwner(lifecycleOwner)
     cameraXController.bindToLifecycle(cameraLifecycleOwner)
   }
 

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
@@ -150,5 +150,6 @@ public actual class CameraSession internal constructor(
   internal fun dispose() {
     state.dispose()
     controller.dispose()
+    cameraXControllerWrapper.dispose()
   }
 }

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
@@ -150,6 +150,5 @@ public actual class CameraSession internal constructor(
   internal fun dispose() {
     state.dispose()
     controller.dispose()
-    cameraXControllerWrapper.unbind()
   }
 }

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/session/CameraSession.android.kt
@@ -143,7 +143,6 @@ public actual class CameraSession internal constructor(
    * This is unusual to make in camerax controller, however to update the preview view or implementation mode, this needs to be made
    * */
   internal fun rebind(lifecycle: LifecycleOwner) {
-    cameraXControllerWrapper.unbind()
     cameraXControllerWrapper.bindToLifecycle(lifecycle)
   }
 

--- a/camposer/src/androidMain/kotlin/com/ujizin/camposer/state/properties/format/CamFormat.android.kt
+++ b/camposer/src/androidMain/kotlin/com/ujizin/camposer/state/properties/format/CamFormat.android.kt
@@ -58,8 +58,6 @@ public actual class CamFormat
       onStabilizationModeChanged: (VideoStabilizationMode) -> Unit,
     ) {
       with(controller) {
-        unbind()
-
         previewResolutionSelector = resolutionSelector
         imageCaptureResolutionSelector = resolutionSelector
         imageAnalysisResolutionSelector = resolutionSelector


### PR DESCRIPTION
## Summary

Removes the explicit `cameraXControllerWrapper.unbind()` call from `CameraSession.dispose()` to fix a dark screen when navigating between screens with cameras. CameraX's `LifecycleCameraController.unbind()` internally calls `ProcessCameraProvider.unbindAll()`, which is a process-wide operation that kills ALL camera sessions — not just the one being disposed. CameraX already manages use case cleanup automatically via lifecycle observation, making explicit unbind unnecessary and harmful in multi-screen scenarios.

Closes #93

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / tooling

## Checklist

- [x] Code formatted (Spotless)
- [ ] Build passes
- [x] No unintentional public API changes
- [ ] Tests written or updated

## Testing notes

- **Platform:** Android (device)
- **Scenarios tested:**
  - Navigate Screen1 (camera) → Screen2 (camera): Screen2 camera works ✅
  - Navigate Screen1 → Screen2 → back to Screen1: Screen1 camera works ✅
- Only `androidMain` files changed — no impact on iOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved camera preview behavior by rebinding the preview whenever the view instance changes.
  * Strengthened camera session teardown by fully disposing the camera controller wrapper during disposal and simplifying rebinding.
* **New Features**
  * Added explicit controller disposal support to ensure reliable camera resource cleanup.
* **Refactor**
  * Streamlined camera controller lifecycle handling with a dedicated per-session lifecycle owner.
* **Tests**
  * Updated the fake camera controller to match the new disposal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->