### PR TITLE
build: bump Kotlin 2.4.0, Compose 1.11.1, Gradle 9.6.0, and other dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
 
   abi_check:
     name: API check
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Check out code
         uses: actions/checkout@v6.0.1
@@ -71,7 +71,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Check out code
         uses: actions/checkout@v6.0.1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   publish:
     name: Release build and publish
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Check out code
         uses: actions/checkout@v6.0.1

--- a/.github/workflows/ios_test.yml
+++ b/.github/workflows/ios_test.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-26
 
     steps:
       - name: Check out code

--- a/buildSrc/src/main/kotlin/ujizin/camposer/Config.kt
+++ b/buildSrc/src/main/kotlin/ujizin/camposer/Config.kt
@@ -1,7 +1,7 @@
 package ujizin.camposer
 
 object Config {
-  const val compileSdk = 36
+  const val compileSdk = 37
   const val minSdk = 23
   const val versionName = "1.0.2"
   const val groupId = "io.github.ujizin"

--- a/camposer-code-scanner/api/camposer-code-scanner.klib.api
+++ b/camposer-code-scanner/api/camposer-code-scanner.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/camposer-code-scanner/build.gradle.kts
+++ b/camposer-code-scanner/build.gradle.kts
@@ -22,9 +22,7 @@ apply(from = "$rootDir/scripts/publish-module.gradle")
 kotlin {
   explicitApi()
 
-  abiValidation {
-    enabled.set(true)
-  }
+  abiValidation()
 
   androidLibrary {
     namespace = "com.ujizin.camposer.code_scanner"
@@ -43,7 +41,6 @@ kotlin {
   }
 
   listOf(
-    iosX64(),
     iosArm64(),
     iosSimulatorArm64(),
   ).forEach { iosTarget ->

--- a/camposer/api/camposer.klib.api
+++ b/camposer/api/camposer.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64]
+// Targets: [iosArm64, iosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/camposer/build.gradle.kts
+++ b/camposer/build.gradle.kts
@@ -34,9 +34,7 @@ kotlin {
 
   explicitApi()
 
-  abiValidation {
-    enabled.set(true)
-  }
+  abiValidation()
 
   androidLibrary {
     namespace = "com.ujizin.camposer"
@@ -51,7 +49,7 @@ kotlin {
     compilerOptions { jvmTarget.set(JvmTarget.JVM_17) }
   }
 
-  listOf(iosX64(), iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
+  listOf(iosArm64(), iosSimulatorArm64()).forEach { iosTarget ->
     iosTarget.binaries.framework {
       baseName = "Camposer"
       isStatic = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,17 +2,17 @@
 
 # Camposer libraries
 
-gradle = "9.0.1"
+gradle = "9.2.1"
 gradle-nexus = "2.0.0"
-spotless = "8.3.0"
+spotless = "8.7.0"
 ktlint = "1.8.0"
-kotlin = "2.3.10"
-dokka = "2.1.0"
+kotlin = "2.4.0"
+dokka = "2.2.0"
 androidx-test = "1.7.0"
 androidx-arch-core = "2.2.0"
 camerax = "1.5.3"
-coroutines = "1.10.2"
-compose-multiplatform = "1.10.2"
+coroutines = "1.11.0"
+compose-multiplatform = "1.11.1"
 binary-compatibility-validator = "0.18.1"
 maven-publish = "0.36.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue Aug 26 22:31:30 WEST 2025
+#Fri Jun 26 00:30:13 WEST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/gradle/libs.versions.toml
+++ b/samples/gradle/libs.versions.toml
@@ -1,37 +1,37 @@
 [versions]
 
-agp = "9.0.1"
+agp = "9.2.1"
 camposer = "1.0.0"
-kotlin = "2.3.0"
-compose-multiplatform = "1.10.1"
-compose-bom = "2026.01.00"
+kotlin = "2.4.0"
+compose-multiplatform = "1.11.1"
+compose-bom = "2026.06.00"
 exoplayer = "2.19.1"
 zxing = "3.5.4"
-cloudy = "0.5.0"
-appcompat = "1.12.2"
-material = "1.13.0"
+cloudy = "0.6.0"
+appcompat = "1.13.0"
+material = "1.14.0"
 material3 = "1.9.0"
-lifecycle = "2.10.0"
-kmp-lifecycle = "2.9.6"
-navigation = "2.9.6"
-kotlinx-serialization = "1.10.0"
+lifecycle = "2.11.0"
+kmp-lifecycle = "2.10.0"
+navigation = "2.9.8"
+kotlinx-serialization = "1.11.0"
 accompanist = "0.37.3"
 coil = "2.7.0"
-koin = "4.1.1"
-datastore = "1.2.0"
+koin = "4.2.2"
+datastore = "1.2.1"
 
 # kmp
-kotlinx-io = "0.8.2"
+kotlinx-io = "0.9.0"
 core-ktx = "1.17.0"
 multiplatform-nav3-ui = "1.0.0-alpha06"
 moko-permissions = "0.20.1"
-coil3 = "3.3.0"
+coil3 = "3.5.0"
 filekit = "0.12.0"
 
 [libraries]
 
-camposer = { module = "io.github.ujizin:camposer", version.ref = "camposer" }
-camposer-code-scanner = { module = "io.github.ujizin:camposer-code-scanner", version.ref = "camposer" }
+camposer = { module = "io.github.ujizin:camposer" }
+camposer-code-scanner = { module = "io.github.ujizin:camposer-code-scanner" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 koin = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 datastore = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }

--- a/samples/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Tue Jan 06 22:38:18 WET 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/samples/sample-android/build.gradle.kts
+++ b/samples/sample-android/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
   namespace = "com.ujizin.sample"
-  compileSdk = 36
+  compileSdk = 37
   defaultConfig {
     versionCode = 1
     versionName = "1.0.0"

--- a/samples/sample-multiplatform/sample-kmp-android/build.gradle.kts
+++ b/samples/sample-multiplatform/sample-kmp-android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 android {
   namespace = "com.ujizin.camposer.sample.sample_kmp_android"
   compileSdk {
-    version = release(36)
+    version = release(37)
   }
 
   defaultConfig {

--- a/samples/sample-multiplatform/shared/build.gradle.kts
+++ b/samples/sample-multiplatform/shared/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 kotlin {
   androidLibrary {
     namespace = "com.ujizin.camposer.shared"
-    compileSdk = 36
+    compileSdk = 37
     minSdk = 23
 
     androidResources { enable = true }
@@ -25,12 +25,6 @@ kotlin {
   }
 
   val xcfName = "sharedKit"
-
-  iosX64 {
-    binaries.framework {
-      baseName = xcfName
-    }
-  }
 
   iosArm64 {
     binaries.framework {


### PR DESCRIPTION
## Summary

Bumps major dependencies across the project and samples. Key changes: Kotlin 2.3.10 → 2.4.0, Compose Multiplatform 1.10.2 → 1.11.1, Gradle 9.1.0 → 9.6.0, AGP 9.0.1 → 9.2.1, compileSdk 36 → 37. Removes `iosX64` target (dropped by Compose Multiplatform 1.11.1). CameraX stays at 1.5.3 — bump deferred to a separate PR.

### Version changes

| Library | Old | New |
|---------|-----|-----|
| Kotlin | 2.3.10 | 2.4.0 |
| Compose Multiplatform | 1.10.2 | 1.11.1 |
| Gradle wrapper | 9.1.0 | 9.6.0 |
| AGP | 9.0.1 | 9.2.1 |
| Spotless | 8.3.0 | 8.7.0 |
| Dokka | 2.1.0 | 2.2.0 |
| Coroutines | 1.10.2 | 1.11.0 |
| compileSdk | 36 | 37 |

### Other changes
- Removed `iosX64()` target (no longer published by Compose Multiplatform 1.11.1)
- Simplified `abiValidation { enabled.set(true) }` → `abiValidation()`
- Bumped sample dependencies (compose-bom, lifecycle, navigation, coil3, koin, etc.)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / tooling

## Checklist

- [x] Code formatted (Spotless)
- [x] Build passes
- [x] No unintentional public API changes
- [ ] Tests written or updated

## Testing notes

- Full build passes (`./gradlew build`)
- iOS simulator tests pass (`./gradlew iosSimulatorArm64Test`)
- Dokka HTML generation passes
- Android sample builds (`assembleDebug`)
- KMP sample builds (`assembleDebug`)
- ABI baseline updated (only `iosX64` target removed from `.klib.api` files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated build tooling and dependencies to newer versions for a smoother development and release experience.
  * Moved CI and test jobs to a newer macOS runner for improved consistency.

* **Bug Fixes**
  * Increased Android compile settings to the latest supported level.
  * Simplified iOS target support by removing the outdated x64 simulator target from builds and ABI metadata.

* **Chores**
  * Updated Gradle wrapper versions across the project and samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->