### PR TITLE
refactor(ios): remove mute during recording and enable audio on video capture mode

### DIFF
--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/controller/IOSRecordController.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/controller/IOSRecordController.kt
@@ -3,6 +3,7 @@ package com.ujizin.camposer.internal.controller
 import com.ujizin.camposer.internal.core.ios.IOSCameraController
 import com.ujizin.camposer.internal.error.CameraNotRunningException
 import com.ujizin.camposer.internal.error.ErrorRecordVideoException
+import com.ujizin.camposer.internal.error.MuteNotSupportedException
 import com.ujizin.camposer.internal.error.VideoOutputNotFoundException
 import com.ujizin.camposer.internal.extensions.firstIsInstanceOrNull
 import com.ujizin.camposer.internal.extensions.setMirrorEnabled
@@ -76,7 +77,6 @@ internal class IOSRecordController(
       }
     }.apply { videoDelegate = this }
 
-    cameraController.setAudioEnabled(!_isMuted.value)
     videoRecordOutput.startRecordingToOutputFileURL(
       outputFileURL = NSURL.fileURLWithPath(filename),
       recordingDelegate = videoDelegate,
@@ -101,18 +101,10 @@ internal class IOSRecordController(
     return Result.success(true)
   }
 
-  fun mute(isMuted: Boolean): Result<Boolean> {
-    _isMuted.update { isMuted }
-    if (_isRecording.value) {
-      cameraController.setAudioEnabled(!isMuted)
-    }
-    return Result.success(true)
-  }
+  fun mute(isMuted: Boolean): Result<Boolean> = Result.failure(MuteNotSupportedException())
 
   private fun clearRecord() {
-    cameraController.setAudioEnabled(false)
     _isRecording.update { false }
-    _isMuted.update { false }
   }
 
   private fun NSError?.isRecordingStoppedAfterSuccessfulFinish(): Boolean {

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/core/applier/SessionTopologyApplier.ios.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/core/applier/SessionTopologyApplier.ios.kt
@@ -62,6 +62,7 @@ internal class SessionTopologyApplier(
     iOSCameraController.withSessionConfiguration {
       previousCaptureMode.findOutput()?.let { iOSCameraController.removeOutput(it) }
       iOSCameraController.addOutput(captureMode.createOutput())
+      iOSCameraController.setAudioEnabled(captureMode == CaptureMode.Video)
       updateConfig(captureMode = captureMode, captureModeChanged = true)
     }
     cameraState.updateCaptureMode(captureMode)

--- a/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/error/Errors.kt
+++ b/camposer/src/iosMain/kotlin/com/ujizin/camposer/internal/error/Errors.kt
@@ -44,3 +44,6 @@ internal class VideoOutputNotFoundException : CameraException("Video output not 
 internal class PhotoOutputNotFoundException : CameraException("Photo output not found")
 
 internal class AudioInputNotFoundException : CameraException("Audio input not found")
+
+internal class MuteNotSupportedException :
+  CameraException("Mute recording is not supported on iOS")

--- a/camposer/src/iosTest/kotlin/com/ujizin/camposer/fake/FakeIosCameraController.kt
+++ b/camposer/src/iosTest/kotlin/com/ujizin/camposer/fake/FakeIosCameraController.kt
@@ -72,7 +72,6 @@ class FakeIosCameraController : IOSCameraController {
   var fakeIsZSLSupported: Boolean = true
     internal set
 
-  private val mutableFakeIsMuted = MutableStateFlow(false)
   private val mutableFakeIsRecording = MutableStateFlow(false)
 
   private var position: AVCaptureDevicePosition = AVCaptureDevicePositionUnspecified
@@ -106,6 +105,7 @@ class FakeIosCameraController : IOSCameraController {
   override val isFocusSupported: Boolean
     get() = fakeIsFocusSupported
 
+  private val mutableFakeIsMuted = MutableStateFlow(false)
   override val isMuted: StateFlow<Boolean> = mutableFakeIsMuted.asStateFlow()
 
   override val isRecording: StateFlow<Boolean> = mutableFakeIsRecording.asStateFlow()
@@ -232,7 +232,6 @@ class FakeIosCameraController : IOSCameraController {
     filename: String,
     onVideoCaptured: (Result<String>) -> Unit,
   ) {
-    setAudioEnabled(!mutableFakeIsMuted.value)
     mutableFakeIsRecording.update { true }
 
     if (fakeErrorInRecording) {
@@ -248,19 +247,12 @@ class FakeIosCameraController : IOSCameraController {
   override fun pauseRecording(): Result<Boolean> = Result.success(true)
 
   override fun stopRecording(): Result<Boolean> {
-    setAudioEnabled(false)
     mutableFakeIsRecording.update { false }
-    mutableFakeIsMuted.update { false }
     return Result.success(true)
   }
 
-  override fun muteRecording(isMuted: Boolean): Result<Boolean> {
-    mutableFakeIsMuted.update { isMuted }
-    if (mutableFakeIsRecording.value) {
-      setAudioEnabled(!isMuted)
-    }
-    return Result.success(true)
-  }
+  override fun muteRecording(isMuted: Boolean): Result<Boolean> =
+    Result.failure(UnsupportedOperationException("Mute recording is not supported on iOS"))
 
   override fun release() {
     isFakeReleased = true

--- a/camposer/src/iosTest/kotlin/com/ujizin/camposer/internal/controller/IOSRecordControllerTest.kt
+++ b/camposer/src/iosTest/kotlin/com/ujizin/camposer/internal/controller/IOSRecordControllerTest.kt
@@ -35,13 +35,11 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalForeignApi::class)
 internal class IOSRecordControllerTest {
   @Test
-  fun test_stop_does_not_duplicate_audio_cleanup_when_delegate_finishes() {
+  fun test_stop_does_not_duplicate_cleanup_when_delegate_finishes() {
     val output = TestMovieFileOutput()
     val cameraController = TestIOSCameraController(output)
     val recordController = IOSRecordController(cameraController)
     var callbackCount = 0
-
-    assertFalse(cameraController.isAudioEnabled)
 
     recordController.start(
       filename = "/video/video.mp4",
@@ -50,21 +48,16 @@ internal class IOSRecordControllerTest {
       onVideoCaptured = { callbackCount++ },
     )
 
-    assertTrue(cameraController.isAudioEnabled)
     assertTrue(recordController.isRecording.value)
 
     recordController.stop()
 
-    assertFalse(cameraController.isAudioEnabled)
     assertFalse(recordController.isRecording.value)
-    assertFalse(recordController.isMuted.value)
 
     output.finishRecording()
 
-    assertFalse(cameraController.isAudioEnabled)
     assertEquals(1, callbackCount)
     assertFalse(recordController.isRecording.value)
-    assertFalse(recordController.isMuted.value)
   }
 
   @Test
@@ -81,9 +74,7 @@ internal class IOSRecordControllerTest {
       onVideoCaptured = { capturedResult = it },
     )
 
-    assertTrue(cameraController.isAudioEnabled)
     assertTrue(recordController.isRecording.value)
-    assertFalse(recordController.isMuted.value)
 
     output.finishRecording(
       error = NSError.errorWithDomain(
@@ -97,8 +88,6 @@ internal class IOSRecordControllerTest {
     assertTrue(result.isSuccess)
     assertEquals("/video/video.mp4", result.getOrNull())
     assertFalse(recordController.isRecording.value)
-    assertFalse(recordController.isMuted.value)
-    assertFalse(cameraController.isAudioEnabled)
   }
 }
 
@@ -152,8 +141,7 @@ private class TestIOSCameraController(
   override val isTorchAvailable: Boolean = false
   override val hasTorch: Boolean = false
 
-  private val _isMuted = MutableStateFlow(false)
-  override val isMuted: StateFlow<Boolean> = _isMuted
+  override val isMuted: StateFlow<Boolean> = MutableStateFlow(false)
   override val isRecording: StateFlow<Boolean> = MutableStateFlow(false)
 
   override fun isZeroShutterLagSupported(output: AVCaptureOutput): Boolean = false
@@ -246,10 +234,8 @@ private class TestIOSCameraController(
 
   override fun stopRecording(): Result<Boolean> = error("Unused in test")
 
-  override fun muteRecording(isMuted: Boolean): Result<Boolean> {
-    _isMuted.value = isMuted
-    return Result.success(isMuted)
-  }
+  override fun muteRecording(isMuted: Boolean): Result<Boolean> =
+    Result.failure(UnsupportedOperationException("Mute recording is not supported on iOS"))
 
   override fun detachPreviewLayer() = Unit
 

--- a/camposer/src/iosTest/kotlin/com/ujizin/camposer/session/CameraRecordAudioLifecycleTest.kt
+++ b/camposer/src/iosTest/kotlin/com/ujizin/camposer/session/CameraRecordAudioLifecycleTest.kt
@@ -7,10 +7,30 @@ import kotlin.test.assertTrue
 
 internal class CameraRecordAudioLifecycleTest : CameraSessionTest() {
   @Test
-  fun test_audio_input_is_only_enabled_while_recording() {
+  fun test_audio_input_is_enabled_when_switching_to_video_mode() {
+    assertFalse(cameraTest.fakeIosCameraController.fakeAudioEnabled)
+
     updateSession(captureMode = CaptureMode.Video)
 
+    assertTrue(cameraTest.fakeIosCameraController.fakeAudioEnabled)
+  }
+
+  @Test
+  fun test_audio_input_is_disabled_when_switching_to_image_mode() {
+    updateSession(captureMode = CaptureMode.Video)
+
+    assertTrue(cameraTest.fakeIosCameraController.fakeAudioEnabled)
+
+    updateSession(captureMode = CaptureMode.Image)
+
     assertFalse(cameraTest.fakeIosCameraController.fakeAudioEnabled)
+  }
+
+  @Test
+  fun test_audio_stays_enabled_during_recording_lifecycle() {
+    updateSession(captureMode = CaptureMode.Video)
+
+    assertTrue(cameraTest.fakeIosCameraController.fakeAudioEnabled)
 
     controller.startRecording("/video/video.mp4") { }
 
@@ -18,25 +38,16 @@ internal class CameraRecordAudioLifecycleTest : CameraSessionTest() {
 
     controller.stopRecording()
 
-    assertFalse(cameraTest.fakeIosCameraController.fakeAudioEnabled)
+    assertTrue(cameraTest.fakeIosCameraController.fakeAudioEnabled)
   }
 
   @Test
-  fun test_preconfigured_mute_is_preserved_when_recording_starts() {
+  fun test_mute_recording_returns_failure_on_ios() {
     updateSession(captureMode = CaptureMode.Video)
 
-    controller.muteRecording(true)
+    val result = controller.muteRecording(true)
 
-    assertTrue(controller.isMuted.value)
-
-    controller.startRecording("/video/video.mp4") { }
-
-    assertTrue(controller.isMuted.value)
-    assertFalse(cameraTest.fakeIosCameraController.fakeAudioEnabled)
-
-    controller.muteRecording(false)
-
+    assertTrue(result.isFailure)
     assertFalse(controller.isMuted.value)
-    assertTrue(cameraTest.fakeIosCameraController.fakeAudioEnabled)
   }
 }

--- a/docs/camera-controller/record-video.md
+++ b/docs/camera-controller/record-video.md
@@ -57,6 +57,19 @@ cameraController.resumeRecording()
 
 - `resumeRecording` continues the same recording session without creating a new file.
 
+## Mute Recording
+
+Mute or unmute the audio during recording:
+
+```kotlin
+cameraController.muteRecording(isMuted = true)
+```
+
+- `isMuted` state is available via `cameraController.isMuted`.
+
+!!! warning "iOS limitation"
+    Mute recording is **not supported on iOS**. Calling `muteRecording` on iOS always returns `Result.failure`. Audio input is enabled automatically when switching to `CaptureMode.Video` and cannot be toggled during recording.
+
 ## Android-Specific API
 
 On Android, `CameraController.startRecording` supports additional options to provide more control over file handling:


### PR DESCRIPTION
## Summary

Remove mute/unmute audio support during iOS video recording. AVFoundation cannot add/remove audio input while a capture session is recording, which caused a camera blink. Audio input is now enabled when switching to `CaptureMode.Video` inside the same `withSessionConfiguration` block as the output swap. `muteRecording` on iOS always returns `Result.failure(MuteNotSupportedException)`.

## Type of change

- [ ] Bug fix
- [x] Refactor
- [x] Docs / tooling

## Checklist

- [ ] Code formatted (Spotless)
- [ ] Build passes
- [ ] No unintentional public API changes
- [x] Tests written or updated

## Testing notes

- **Platform:** iOS only
- Updated `CameraRecordAudioLifecycleTest` to verify audio is enabled on video mode switch (not recording start), stays enabled during recording lifecycle, and mute returns failure
- Updated `IOSRecordControllerTest` to remove audio assertions (record controller no longer manages audio)
- `FakeIosCameraController` updated to match new behavior
- Docs updated with iOS mute limitation note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for recording controls, including how to check mute status and switch audio behavior during video capture.

* **Bug Fixes**
  * iOS now clearly reports that muting during recording is not supported, instead of silently changing audio state.
  * Audio handling is more consistent when switching between video and image capture modes.
  * Recording stop/cleanup behavior was simplified to avoid duplicate state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->